### PR TITLE
[Task] 게이트웨이에서 JWT 인증 헤더 기반 X-USER-ID 추출로 전환

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,21 +74,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>io.jsonwebtoken</groupId>
-			<artifactId>jjwt-api</artifactId>
-			<version>0.12.3</version>
-		</dependency>
-		<dependency>
-			<groupId>io.jsonwebtoken</groupId>
-			<artifactId>jjwt-impl</artifactId>
-			<version>0.12.6</version>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>io.jsonwebtoken</groupId>
-			<artifactId>jjwt-jackson</artifactId>
-			<version>0.12.5</version>
-			<scope>runtime</scope>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/nhnacademy/gatewayservice/domain/RefreshTokenResponseDto.java
+++ b/src/main/java/com/nhnacademy/gatewayservice/domain/RefreshTokenResponseDto.java
@@ -1,7 +1,0 @@
-package com.nhnacademy.gatewayservice.domain;
-
-public record RefreshTokenResponseDto(
-        String accessToken,
-        String refreshToken
-) {
-}

--- a/src/main/java/com/nhnacademy/gatewayservice/filter/AuthorizationHeaderFilter.java
+++ b/src/main/java/com/nhnacademy/gatewayservice/filter/AuthorizationHeaderFilter.java
@@ -1,20 +1,13 @@
 package com.nhnacademy.gatewayservice.filter;
 
-import com.nhnacademy.gatewayservice.domain.RefreshTokenResponseDto;
 import com.nhnacademy.gatewayservice.domain.TokenParseResponseDto;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
-import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
-import org.springframework.http.HttpCookie;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.server.reactive.ServerHttpRequest;
-import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.server.ServerWebExchange;
-import reactor.core.publisher.Mono;
 
 @Slf4j
 @Component
@@ -22,12 +15,6 @@ public class AuthorizationHeaderFilter extends AbstractGatewayFilterFactory<Auth
     private static final String X_USER_ID_HEADER = "X-USER-ID";
 
     private final WebClient.Builder webClientBuilder;
-
-    @Value("${custom.security.jwt.access-token-expiration}")
-    private int accessTokenExpiration;
-
-    @Value("${custom.security.jwt.refresh-token-expiration}")
-    private int refreshTokenExpiration;
 
     public AuthorizationHeaderFilter(WebClient.Builder webClientBuilder) {
         super(Config.class);
@@ -38,79 +25,33 @@ public class AuthorizationHeaderFilter extends AbstractGatewayFilterFactory<Auth
     public GatewayFilter apply(Config config) {
         return (exchange, chain) -> {
             ServerHttpRequest request = exchange.getRequest();
-            HttpCookie accessTokenCookie = request.getCookies().getFirst("accessToken");
-
-            if(accessTokenCookie != null) {
-                String accessToken = accessTokenCookie.getValue();
-                log.debug("accessToken 존재, 파싱 시도");
-                return parseTokenAndForward(accessToken, request, exchange, chain)
+            String authHeader = request.getHeaders().getFirst("Authorization");
+            if(authHeader != null && authHeader.startsWith("Bearer ")) {
+                String accessToken = StringUtils.removeStart(authHeader, "Bearer ");
+                log.debug("Authorization 헤더에서 토큰 추출, 파싱 시도");
+                return webClientBuilder.build()
+                        .post()
+                        .uri("lb://auth-service/auth/parse")
+                        .bodyValue(accessToken)
+                        .retrieve()
+                        .bodyToMono(TokenParseResponseDto.class)
+                        .flatMap(parseResponse -> {
+                            log.info("accessToken 파싱 성공, userId: {}", parseResponse.username());
+                            ServerHttpRequest mutatedRequest = request.mutate()
+                                    .header(X_USER_ID_HEADER, parseResponse.username())
+                                    .build();
+                            return chain.filter(exchange.mutate().request(mutatedRequest).build());
+                        })
                         .onErrorResume(e -> {
-                            log.warn("accessToken 파싱 실패: {}, refreshToken 재발급 시도", e.getMessage());
-                            return tryRefreshTokenAndForward(request, exchange, chain);
+                            log.warn("accessToken 파싱 실패: {}, 인증 없이 통과", e.getMessage());
+
+                            return chain.filter(exchange);
                         });
             } else {
-                log.debug("accessToken 없음, refreshToken 확인");
-                return tryRefreshTokenAndForward(request, exchange, chain);
+                log.debug("Authorization 헤더 없음, 인증 없이 통과");
+                return chain.filter(exchange);
             }
         };
-    }
-
-    private Mono<Void> parseTokenAndForward(String token, ServerHttpRequest request, ServerWebExchange exchange, GatewayFilterChain chain) {
-        return webClientBuilder.build()
-                .post()
-                .uri("lb://auth-service/auth/parse")
-                .bodyValue(token)
-                .retrieve()
-                .bodyToMono(TokenParseResponseDto.class)
-                .flatMap(parseResponse -> {
-                    log.info("accessToken 파싱 성공, userId: {}", parseResponse.username());
-                    ServerHttpRequest mutatedRequest = addUserIdHeader(request, parseResponse.username());
-                    return chain.filter(exchange.mutate().request(mutatedRequest).build());
-                });
-    }
-
-    private Mono<Void> tryRefreshTokenAndForward(ServerHttpRequest request, ServerWebExchange exchange, GatewayFilterChain chain) {
-        HttpCookie refreshTokenCookie = request.getCookies().getFirst("refreshToken");
-        if(refreshTokenCookie == null) {
-            log.debug("refreshToken 없음, 인증 없이 통과");
-            return chain.filter(exchange);
-        }
-        String refreshToken = refreshTokenCookie.getValue();
-        log.debug("refreshToken 존재, accessToken 재발급 시도");
-        return webClientBuilder.build()
-                .post()
-                .uri("lb://auth-service/auth/refresh")
-                .bodyValue(refreshToken)
-                .retrieve()
-                .bodyToMono(RefreshTokenResponseDto.class)
-                .flatMap(tokenResponse -> {
-                    log.info("accessToken 재발급 성공");
-                    addTokenCookies(exchange.getResponse(), tokenResponse);
-                    return parseTokenAndForward(tokenResponse.accessToken(), request, exchange, chain)
-                            .onErrorResume(e -> {
-                                log.warn("재발급된 accessToken 파싱 실패: {}", e.getMessage());
-                                return chain.filter(exchange);
-                            });
-                })
-                .onErrorResume(e -> {
-                    log.warn("refreshToken 재발급 실패: {}", e.getMessage());
-                    return chain.filter(exchange);
-                });
-    }
-
-    private ServerHttpRequest addUserIdHeader(ServerHttpRequest request, String userId) {
-        return request.mutate()
-                .header(X_USER_ID_HEADER, userId)
-                .build();
-    }
-
-    private void addTokenCookies(ServerHttpResponse response, RefreshTokenResponseDto tokenResponse) {
-        ResponseCookie accessCookie = ResponseCookie.from("accessToken", tokenResponse.accessToken())
-                .httpOnly(true).secure(true).path("/").maxAge(accessTokenExpiration).build();
-        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", tokenResponse.refreshToken())
-                .httpOnly(true).secure(true).path("/").maxAge(refreshTokenExpiration).build();
-        response.addCookie(accessCookie);
-        response.addCookie(refreshCookie);
     }
 
     public static class Config {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,9 +49,3 @@ eureka:
       defaultZone: http://localhost:10344/eureka,http://localhost:10345/eureka
     register-with-eureka: true
     fetch-registry: true
-
-custom:
-  security:
-    jwt:
-      access-token-expiration: 3600
-      refresh-token-expiration: 604800

--- a/src/test/java/com/nhnacademy/gatewayservice/filter/AuthorizationHeaderFilterTest.java
+++ b/src/test/java/com/nhnacademy/gatewayservice/filter/AuthorizationHeaderFilterTest.java
@@ -1,22 +1,22 @@
 package com.nhnacademy.gatewayservice.filter;
 
-import com.nhnacademy.gatewayservice.domain.RefreshTokenResponseDto;
 import com.nhnacademy.gatewayservice.domain.TokenParseResponseDto;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
-import org.springframework.http.HttpCookie;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -26,206 +26,104 @@ class AuthorizationHeaderFilterTest {
     private WebClient.Builder webClientBuilder;
     @Mock
     private WebClient webClient;
+    @Mock
+    private WebClient.RequestBodyUriSpec uriSpec;
+    @Mock
+    private WebClient.RequestHeadersSpec<?> headersSpec;
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
+    @Mock
+    private GatewayFilterChain filterChain;
 
+    @InjectMocks
     private AuthorizationHeaderFilter filter;
 
-    @BeforeEach
-    void setUp() {
-        // lenient로 UnnecessaryStubbingException 방지
-        lenient().when(webClientBuilder.build()).thenReturn(webClient);
-        filter = new AuthorizationHeaderFilter(webClientBuilder);
-    }
-
     @Test
-    void shouldAddXUserIdHeaderWhenAccessTokenIsValid() {
-        String accessToken = "validAccessToken";
-        String userId = "user1";
-        MockServerHttpRequest request = MockServerHttpRequest.get("/test")
-                .cookie(new HttpCookie("accessToken", accessToken))
-                .build();
-        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+    void withoutAuthorizationHeader_shouldSkipFilter() {
+        when(filterChain.filter(any())).thenReturn(Mono.empty());
 
-        GatewayFilterChain chain = mock(GatewayFilterChain.class);
-        when(chain.filter(any())).thenReturn(Mono.empty());
-
-        // WebClient 체인 mock
-        WebClient.RequestBodyUriSpec uriSpec = mock(WebClient.RequestBodyUriSpec.class);
-        WebClient.RequestBodySpec bodySpec = mock(WebClient.RequestBodySpec.class);
-        WebClient.RequestHeadersSpec<?> headersSpec = mock(WebClient.RequestHeadersSpec.class);
-        WebClient.ResponseSpec responseSpec = mock(WebClient.ResponseSpec.class);
-
-        when(webClient.post()).thenReturn(uriSpec);
-        when(uriSpec.uri(anyString())).thenReturn(bodySpec);
-        doReturn(headersSpec).when(bodySpec).bodyValue(any());
-        when(headersSpec.retrieve()).thenReturn(responseSpec);
-        when(responseSpec.bodyToMono(TokenParseResponseDto.class)).thenReturn(
-                Mono.just(new TokenParseResponseDto(userId, null))
-        );
-
-        filter.apply(new AuthorizationHeaderFilter.Config()).filter(exchange, chain).block();
-
-        assertThat(exchange.getRequest().getHeaders().getFirst("X-USER-ID")).isEqualTo(userId);
-        verify(chain, times(1)).filter(any());
-    }
-
-    @Test
-    void shouldAddXUserIdHeaderWhenAccessTokenIsExpiredAndRefreshTokenSucceeds() {
-        String expiredAccessToken = "expiredAccessToken";
-        String refreshToken = "refreshToken";
-        String newAccessToken = "newAccessToken";
-        String newRefreshToken = "newRefreshToken";
-        String userId = "user2";
-        MockServerHttpRequest request = MockServerHttpRequest.get("/test")
-                .cookie(new HttpCookie("accessToken", expiredAccessToken))
-                .cookie(new HttpCookie("refreshToken", refreshToken))
-                .build();
-        MockServerWebExchange exchange = MockServerWebExchange.from(request);
-
-        GatewayFilterChain chain = mock(GatewayFilterChain.class);
-        when(chain.filter(any())).thenReturn(Mono.empty());
-
-        // WebClient 체인 mock (파싱 실패, refresh 성공, 새 토큰 파싱 성공)
-        WebClient.RequestBodyUriSpec uriSpec = mock(WebClient.RequestBodyUriSpec.class);
-        WebClient.RequestBodySpec bodySpec = mock(WebClient.RequestBodySpec.class);
-        WebClient.RequestHeadersSpec<?> headersSpec = mock(WebClient.RequestHeadersSpec.class);
-
-        WebClient.ResponseSpec parseFailSpec = mock(WebClient.ResponseSpec.class);
-        WebClient.ResponseSpec refreshSuccessSpec = mock(WebClient.ResponseSpec.class);
-        WebClient.ResponseSpec parseSuccessSpec = mock(WebClient.ResponseSpec.class);
-
-        when(webClient.post()).thenReturn(uriSpec);
-        when(uriSpec.uri(contains("/auth/parse"))).thenReturn(bodySpec);
-        when(uriSpec.uri(contains("/auth/refresh"))).thenReturn(bodySpec);
-
-        doReturn(headersSpec).when(bodySpec).bodyValue(any());
-        when(headersSpec.retrieve())
-                .thenReturn(parseFailSpec)      // 첫 번째: accessToken 파싱 실패
-                .thenReturn(refreshSuccessSpec) // 두 번째: refreshToken 성공
-                .thenReturn(parseSuccessSpec);  // 세 번째: 새 accessToken 파싱 성공
-
-        when(parseFailSpec.bodyToMono(TokenParseResponseDto.class)).thenReturn(
-                Mono.error(new RuntimeException("expired"))
-        );
-        when(refreshSuccessSpec.bodyToMono(RefreshTokenResponseDto.class)).thenReturn(
-                Mono.just(new RefreshTokenResponseDto(newAccessToken, newRefreshToken))
-        );
-        when(parseSuccessSpec.bodyToMono(TokenParseResponseDto.class)).thenReturn(
-                Mono.just(new TokenParseResponseDto(userId, null))
-        );
-
-        filter.apply(new AuthorizationHeaderFilter.Config()).filter(exchange, chain).block();
-
-        assertThat(exchange.getRequest().getHeaders().getFirst("X-USER-ID")).isEqualTo(userId);
-        verify(chain, times(1)).filter(any());
-    }
-
-    @Test
-    void shouldPassThroughWhenNoTokensPresent() {
         MockServerHttpRequest request = MockServerHttpRequest.get("/test").build();
         MockServerWebExchange exchange = MockServerWebExchange.from(request);
 
-        GatewayFilterChain chain = mock(GatewayFilterChain.class);
-        when(chain.filter(any())).thenReturn(Mono.empty());
+        GatewayFilter gatewayFilter = filter.apply(new AuthorizationHeaderFilter.Config());
+        Mono<Void> result = gatewayFilter.filter(exchange, filterChain);
 
-        filter.apply(new AuthorizationHeaderFilter.Config()).filter(exchange, chain).block();
-
-        assertThat(exchange.getRequest().getHeaders().getFirst("X-USER-ID")).isNull();
-        verify(chain, times(1)).filter(any());
+        StepVerifier.create(result).verifyComplete();
+        verify(filterChain).filter(exchange);  // 원본 Exchange 그대로 전달
     }
 
     @Test
-    void shouldPassThroughWhenRefreshTokenFails() {
-        String expiredAccessToken = "expiredAccessToken";
-        String refreshToken = "refreshToken";
+    void withValidBearerHeader_shouldInjectXUserIdAndContinue() {
+        String token = "validToken123";
+        String userId = "user42";
+
+        // WebClient 모킹 세팅
+        when(webClientBuilder.build()).thenReturn(webClient);
+        when(webClient.post()).thenReturn(uriSpec);
+        when(uriSpec.uri("lb://auth-service/auth/parse")).thenReturn(uriSpec);
+        doReturn(headersSpec).when(uriSpec).bodyValue(token);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(TokenParseResponseDto.class))
+                .thenReturn(Mono.just(new TokenParseResponseDto(userId, null)));
+        when(filterChain.filter(any())).thenReturn(Mono.empty());
+
         MockServerHttpRequest request = MockServerHttpRequest.get("/test")
-                .cookie(new HttpCookie("accessToken", expiredAccessToken))
-                .cookie(new HttpCookie("refreshToken", refreshToken))
+                .header("Authorization", "Bearer " + token)
                 .build();
         MockServerWebExchange exchange = MockServerWebExchange.from(request);
 
-        GatewayFilterChain chain = mock(GatewayFilterChain.class);
-        when(chain.filter(any())).thenReturn(Mono.empty());
+        GatewayFilter gatewayFilter = filter.apply(new AuthorizationHeaderFilter.Config());
+        Mono<Void> result = gatewayFilter.filter(exchange, filterChain);
 
-        // WebClient 체인 mock (파싱 실패, refresh 실패)
-        WebClient.RequestBodyUriSpec uriSpec = mock(WebClient.RequestBodyUriSpec.class);
-        WebClient.RequestBodySpec bodySpec = mock(WebClient.RequestBodySpec.class);
-        WebClient.RequestHeadersSpec<?> headersSpec = mock(WebClient.RequestHeadersSpec.class);
+        ArgumentCaptor<org.springframework.web.server.ServerWebExchange> captor =
+                ArgumentCaptor.forClass(org.springframework.web.server.ServerWebExchange.class);
 
-        WebClient.ResponseSpec parseFailSpec = mock(WebClient.ResponseSpec.class);
-        WebClient.ResponseSpec refreshFailSpec = mock(WebClient.ResponseSpec.class);
+        StepVerifier.create(result).verifyComplete();
+        verify(filterChain).filter(captor.capture());
 
-        when(webClient.post()).thenReturn(uriSpec);
-        when(uriSpec.uri(contains("/auth/parse"))).thenReturn(bodySpec);
-        when(uriSpec.uri(contains("/auth/refresh"))).thenReturn(bodySpec);
-
-        doReturn(headersSpec).when(bodySpec).bodyValue(any());
-        when(headersSpec.retrieve())
-                .thenReturn(parseFailSpec)      // 첫 번째: accessToken 파싱 실패
-                .thenReturn(refreshFailSpec);   // 두 번째: refreshToken 실패
-
-        when(parseFailSpec.bodyToMono(TokenParseResponseDto.class)).thenReturn(
-                Mono.error(new RuntimeException("expired"))
-        );
-        when(refreshFailSpec.bodyToMono(RefreshTokenResponseDto.class)).thenReturn(
-                Mono.error(new RuntimeException("refreshToken expired"))
-        );
-
-        // 예외가 발생해도 통과해야 하므로 block()에서 예외 발생하지 않음
-        filter.apply(new AuthorizationHeaderFilter.Config()).filter(exchange, chain).block();
-
-        assertThat(exchange.getRequest().getHeaders().getFirst("X-USER-ID")).isNull();
-        verify(chain, times(1)).filter(any());
+        var mutatedExchange = captor.getValue();
+        assertEquals(userId, mutatedExchange.getRequest().getHeaders().getFirst("X-USER-ID"));
     }
 
     @Test
-    void shouldPassThroughWhenAccessTokenParsingFailsAfterRefreshTokenReissue() {
-        String expiredAccessToken = "expiredAccessToken";
-        String refreshToken = "refreshToken";
-        String newAccessToken = "newAccessToken";
-        String newRefreshToken = "newRefreshToken";
+    void withNonBearerHeader_shouldSkipFilter() {
+        when(filterChain.filter(any())).thenReturn(Mono.empty());
+
         MockServerHttpRequest request = MockServerHttpRequest.get("/test")
-                .cookie(new HttpCookie("accessToken", expiredAccessToken))
-                .cookie(new HttpCookie("refreshToken", refreshToken))
+                .header("Authorization", "Token abcdef")
                 .build();
         MockServerWebExchange exchange = MockServerWebExchange.from(request);
 
-        GatewayFilterChain chain = mock(GatewayFilterChain.class);
-        when(chain.filter(any())).thenReturn(Mono.empty());
+        GatewayFilter gatewayFilter = filter.apply(new AuthorizationHeaderFilter.Config());
+        Mono<Void> result = gatewayFilter.filter(exchange, filterChain);
 
-        // WebClient 체인 mock
-        WebClient.RequestBodyUriSpec uriSpec = mock(WebClient.RequestBodyUriSpec.class);
-        WebClient.RequestBodySpec bodySpec = mock(WebClient.RequestBodySpec.class);
-        WebClient.RequestHeadersSpec<?> headersSpec = mock(WebClient.RequestHeadersSpec.class);
+        StepVerifier.create(result).verifyComplete();
+        verify(filterChain).filter(exchange);  // "Bearer "이 아니므로 스킵
+    }
 
-        WebClient.ResponseSpec parseFailSpec1 = mock(WebClient.ResponseSpec.class); // initial accessToken parse fail
-        WebClient.ResponseSpec refreshSuccessSpec = mock(WebClient.ResponseSpec.class); // refreshToken success
-        WebClient.ResponseSpec parseFailSpec2 = mock(WebClient.ResponseSpec.class); // new accessToken parse fail
+    @Test
+    void whenParsingFails_shouldSkipFilter() {
+        String token = "invalidToken";
 
+        when(webClientBuilder.build()).thenReturn(webClient);
         when(webClient.post()).thenReturn(uriSpec);
-        when(uriSpec.uri(contains("/auth/parse"))).thenReturn(bodySpec);
-        when(uriSpec.uri(contains("/auth/refresh"))).thenReturn(bodySpec);
+        when(uriSpec.uri("lb://auth-service/auth/parse")).thenReturn(uriSpec);
+        doReturn(headersSpec).when(uriSpec).bodyValue(token);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(TokenParseResponseDto.class))
+                .thenReturn(Mono.error(new RuntimeException("parse failed")));
+        when(filterChain.filter(any())).thenReturn(Mono.empty());
 
-        doReturn(headersSpec).when(bodySpec).bodyValue(any());
-        when(headersSpec.retrieve())
-                .thenReturn(parseFailSpec1)      // 1. accessToken 파싱 실패
-                .thenReturn(refreshSuccessSpec)  // 2. refreshToken 재발급 성공
-                .thenReturn(parseFailSpec2);     // 3. 새 accessToken 파싱 실패
+        MockServerHttpRequest request = MockServerHttpRequest.get("/test")
+                .header("Authorization", "Bearer " + token)
+                .build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
 
-        when(parseFailSpec1.bodyToMono(TokenParseResponseDto.class)).thenReturn(
-                Mono.error(new RuntimeException("expired"))
-        );
-        when(refreshSuccessSpec.bodyToMono(RefreshTokenResponseDto.class)).thenReturn(
-                Mono.just(new RefreshTokenResponseDto(newAccessToken, newRefreshToken))
-        );
-        when(parseFailSpec2.bodyToMono(TokenParseResponseDto.class)).thenReturn(
-                Mono.error(new RuntimeException("new accessToken parse failed"))
-        );
+        GatewayFilter gatewayFilter = filter.apply(new AuthorizationHeaderFilter.Config());
+        Mono<Void> result = gatewayFilter.filter(exchange, filterChain);
 
-        filter.apply(new AuthorizationHeaderFilter.Config()).filter(exchange, chain).block();
-
-        // 새 accessToken 파싱도 실패했으므로 X-USER-ID 헤더가 없어야 함
-        assertThat(exchange.getRequest().getHeaders().getFirst("X-USER-ID")).isNull();
-        verify(chain, times(1)).filter(any());
+        StepVerifier.create(result).verifyComplete();
+        verify(filterChain).filter(exchange);  // 파싱 실패 시 원본 Exchange 전달
     }
 
 }


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📝 PR 개요

- 게이트웨이에서 JWT 토큰 추출 쿠키 -> 인증헤더로 전환
- 검증 실패 시 refreshToken으로 accessToken 재발급 로직 제거
   - 해당 로직은 프론트엔드에 있는걸로 충분하다고 판단

## 🔗 관련 이슈

- #3 

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작합니다.
- [x] 새로운/수정된 기능에 대한 테스트를 추가했습니다.
- [ ] 문서(README 등)를 최신 상태로 반영했습니다.
- [x] 코드 스타일 가이드 및 커밋 메시지 규칙을 준수했습니다.

## 🖼️ 변경 전/후 스크린샷 (UI 변경 시, 선택)

- 변경된 UI가 있다면 스크린샷을 첨부해 주세요.

## 💬 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 정보나 특이사항을 적어 주세요.
